### PR TITLE
Create simple finance CLI app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.pytest_cache/
+.pytest_cache/
+.venv/
+venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,73 @@
-# test
+# App de Finanças Simples
+
+Aplicativo em linha de comando para registrar entradas e saídas de dinheiro
+em um arquivo JSON local. A ferramenta ajuda a acompanhar o saldo atual e
+os totais movimentados em cada categoria (entradas e saídas).
+
+## Requisitos
+
+- Python 3.10 ou superior
+
+## Instalação
+
+1. Crie e ative um ambiente virtual opcional:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Linux/macOS
+   .venv\\Scripts\\activate   # Windows
+   ```
+2. Instale o projeto (incluindo dependências de desenvolvimento):
+   ```bash
+   pip install -e .[dev]
+   ```
+
+## Uso
+
+Após a instalação, um comando `finance-app` estará disponível. Também é
+possível utilizar o módulo diretamente com `python -m finance_app.cli`.
+
+### Adicionar transações
+
+```bash
+finance-app adicionar entrada "Salário" 3500
+finance-app adicionar saida "Supermercado" 220.75
+```
+
+### Listar transações
+
+```bash
+finance-app listar
+```
+
+Saída esperada:
+
+```
+#  Data e hora           Tipo     Valor        Descrição
+------------------------------------------------------------
+ 1  2023-01-10T09:00:00  Entrada  R$ 3.500,00  Salário
+ 2  2023-01-12T18:30:00  Saída    R$ 220,75    Supermercado
+```
+
+### Resumo financeiro
+
+```bash
+finance-app resumo
+```
+
+```
+Resumo financeiro
+------------------------------
+Entradas: R$ 3.500,00
+Saídas:   R$ 220,75
+Saldo:    R$ 3.279,25
+```
+
+Por padrão os dados são armazenados no arquivo `dados_financeiros.json`
+no diretório atual. Utilize a opção `--arquivo` para informar outro
+local.
+
+## Executar testes
+
+```bash
+pytest
+```

--- a/finance_app/__init__.py
+++ b/finance_app/__init__.py
@@ -1,0 +1,10 @@
+"""Aplicativo simples de finanças pessoais.
+
+Este pacote oferece utilidades para registrar transações de entrada e
+saída de recursos de maneira persistente e uma interface de linha de
+comando para interagir com os dados.
+"""
+
+from .tracker import FinanceTracker, Transaction
+
+__all__ = ["FinanceTracker", "Transaction"]

--- a/finance_app/cli.py
+++ b/finance_app/cli.py
@@ -1,0 +1,111 @@
+"""Interface de linha de comando para o aplicativo de finanças."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .tracker import FinanceTracker
+
+
+DEFAULT_DATA_FILE = Path("dados_financeiros.json")
+
+
+def format_currency(value: float) -> str:
+    """Formata valores monetários utilizando separador brasileiro."""
+
+    formatted = f"R$ {value:,.2f}"
+    return formatted.replace(",", "_").replace(".", ",").replace("_", ".")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Controle simples de entradas e saídas financeiras.",
+    )
+    parser.add_argument(
+        "--arquivo",
+        default=str(DEFAULT_DATA_FILE),
+        help="Caminho para o arquivo JSON onde as transações serão salvas.",
+    )
+
+    subparsers = parser.add_subparsers(dest="comando", required=True)
+
+    adicionar = subparsers.add_parser(
+        "adicionar", help="Registra uma nova transação de entrada ou saída."
+    )
+    adicionar.add_argument(
+        "tipo",
+        choices=sorted(FinanceTracker.VALID_KINDS),
+        help="Tipo da transação: entrada ou saída de recursos.",
+    )
+    adicionar.add_argument(
+        "descricao",
+        help="Descrição breve da transação.",
+    )
+    adicionar.add_argument(
+        "valor",
+        type=float,
+        help="Valor numérico da transação (use ponto como separador decimal).",
+    )
+
+    subparsers.add_parser("listar", help="Lista todas as transações registradas.")
+    subparsers.add_parser(
+        "resumo", help="Mostra o total de entradas, saídas e o saldo atual."
+    )
+
+    return parser
+
+
+def handle_adicionar(args: argparse.Namespace, tracker: FinanceTracker) -> None:
+    transaction = tracker.add_transaction(args.tipo, args.descricao, args.valor)
+    sinal = "+" if transaction.kind == "entrada" else "-"
+    print(
+        "Transação adicionada:",
+        f"{sinal}{format_currency(transaction.value)}",
+        f"[{transaction.timestamp}]",
+        transaction.description,
+    )
+
+
+def handle_listar(tracker: FinanceTracker) -> None:
+    transactions = tracker.list_transactions()
+    if not transactions:
+        print("Nenhuma transação registrada até o momento.")
+        return
+
+    print("#  Data e hora           Tipo     Valor        Descrição")
+    print("-" * 60)
+    for idx, transaction in enumerate(transactions, start=1):
+        tipo = "Entrada" if transaction.kind == "entrada" else "Saída  "
+        valor = format_currency(transaction.value)
+        print(
+            f"{idx:>2} {transaction.timestamp:<19} {tipo:<8} {valor:<12} {transaction.description}",
+        )
+
+
+def handle_resumo(tracker: FinanceTracker) -> None:
+    resumo = tracker.get_summary()
+    print("Resumo financeiro")
+    print("-" * 30)
+    print("Entradas:", format_currency(resumo["entradas"]))
+    print("Saídas:  ", format_currency(resumo["saidas"]))
+    print("Saldo:   ", format_currency(resumo["saldo"]))
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    tracker = FinanceTracker(args.arquivo)
+
+    if args.comando == "adicionar":
+        handle_adicionar(args, tracker)
+    elif args.comando == "listar":
+        handle_listar(tracker)
+    elif args.comando == "resumo":
+        handle_resumo(tracker)
+    else:  # pragma: no cover - proteção futura caso novos comandos sejam criados
+        parser.error("Comando desconhecido")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/finance_app/tracker.py
+++ b/finance_app/tracker.py
@@ -1,0 +1,140 @@
+"""Ferramentas para controlar transações financeiras simples.
+
+O módulo define uma classe :class:`FinanceTracker` que gerencia
+persistência em disco de transações representadas pela classe de dados
+:class:`Transaction`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+
+@dataclass
+class Transaction:
+    """Representa uma transação financeira de entrada ou saída."""
+
+    kind: str
+    description: str
+    value: float
+    timestamp: str
+
+    def to_dict(self) -> dict:
+        """Converte a transação para um dicionário serializável."""
+
+        return {
+            "kind": self.kind,
+            "description": self.description,
+            "value": self.value,
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Transaction":
+        """Cria uma transação a partir de um dicionário."""
+
+        return cls(
+            kind=data["kind"],
+            description=data["description"],
+            value=float(data["value"]),
+            timestamp=data["timestamp"],
+        )
+
+
+class FinanceTracker:
+    """Gerencia uma coleção de transações em um arquivo JSON."""
+
+    VALID_KINDS = {"entrada", "saida"}
+
+    def __init__(self, storage_path: Path | str):
+        self.storage_path = Path(storage_path)
+        if not self.storage_path.parent.exists():
+            self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.storage_path.exists():
+            self._write_transactions([])
+
+    # ------------------------------------------------------------------
+    # Operações internas de leitura e escrita
+    def _read_transactions(self) -> List[Transaction]:
+        if not self.storage_path.exists():
+            return []
+        try:
+            raw_data = json.loads(self.storage_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                "Arquivo de dados corrompido. Não foi possível interpretar o JSON."
+            ) from exc
+        return [Transaction.from_dict(item) for item in raw_data]
+
+    def _write_transactions(self, transactions: Iterable[Transaction]) -> None:
+        data = [t.to_dict() for t in transactions]
+        self.storage_path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    # ------------------------------------------------------------------
+    # API pública
+    def list_transactions(self) -> List[Transaction]:
+        """Retorna todas as transações persistidas."""
+
+        return self._read_transactions()
+
+    def add_transaction(
+        self,
+        kind: str,
+        description: str,
+        value: float,
+        timestamp: datetime | None = None,
+    ) -> Transaction:
+        """Adiciona uma transação de entrada ou saída.
+
+        Args:
+            kind: "entrada" para créditos ou "saida" para débitos.
+            description: Descrição curta da transação.
+            value: Valor positivo da transação.
+            timestamp: Data e hora opcional. Se omitido é utilizado o momento
+                atual.
+        """
+
+        normalized_kind = kind.lower().strip()
+        if normalized_kind not in self.VALID_KINDS:
+            raise ValueError(
+                "Tipo de transação inválido. Utilize 'entrada' ou 'saida'."
+            )
+        if value <= 0:
+            raise ValueError("O valor deve ser positivo.")
+
+        moment = timestamp or datetime.now()
+        transaction = Transaction(
+            kind=normalized_kind,
+            description=description.strip(),
+            value=float(value),
+            timestamp=moment.isoformat(timespec="seconds"),
+        )
+
+        transactions = self._read_transactions()
+        transactions.append(transaction)
+        self._write_transactions(transactions)
+        return transaction
+
+    def get_summary(self) -> dict:
+        """Calcula totais de entrada, saída e saldo."""
+
+        totals = {"entradas": 0.0, "saidas": 0.0}
+        for transaction in self._read_transactions():
+            if transaction.kind == "entrada":
+                totals["entradas"] += transaction.value
+            else:
+                totals["saidas"] += transaction.value
+        totals["saldo"] = totals["entradas"] - totals["saidas"]
+        return totals
+
+    def clear(self) -> None:
+        """Remove todas as transações do arquivo de dados."""
+
+        self._write_transactions([])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "finance-app"
+version = "0.1.0"
+description = "Aplicativo simples de finanças pessoais para registrar entradas e saídas."
+readme = "README.md"
+authors = [{name = "Example", email = "example@example.com"}]
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=7.4"]
+
+[project.scripts]
+finance-app = "finance_app.cli:main"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from pathlib import Path
+
+import json
+
+import pytest
+
+from finance_app.tracker import FinanceTracker
+
+
+def test_add_and_list_transactions(tmp_path: Path) -> None:
+    storage = tmp_path / "dados.json"
+    tracker = FinanceTracker(storage)
+
+    tracker.add_transaction("entrada", "Salário", 2500.0, datetime(2023, 1, 10, 9, 0))
+    tracker.add_transaction("saida", "Aluguel", 1200.0, datetime(2023, 1, 12, 10, 0))
+
+    transactions = tracker.list_transactions()
+    assert len(transactions) == 2
+    assert transactions[0].description == "Salário"
+    assert transactions[0].kind == "entrada"
+    assert transactions[1].kind == "saida"
+
+    saved = json.loads(storage.read_text(encoding="utf-8"))
+    assert saved[0]["description"] == "Salário"
+    assert saved[1]["value"] == 1200.0
+
+
+def test_summary_returns_expected_values(tmp_path: Path) -> None:
+    storage = tmp_path / "dados.json"
+    tracker = FinanceTracker(storage)
+    tracker.add_transaction("entrada", "Freelancer", 800.0, datetime(2023, 2, 1, 14, 30))
+    tracker.add_transaction("saida", "Mercado", 200.0, datetime(2023, 2, 2, 18, 45))
+    tracker.add_transaction("saida", "Transporte", 150.0, datetime(2023, 2, 3, 8, 15))
+
+    resumo = tracker.get_summary()
+    assert resumo["entradas"] == pytest.approx(800.0)
+    assert resumo["saidas"] == pytest.approx(350.0)
+    assert resumo["saldo"] == pytest.approx(450.0)
+
+
+def test_invalid_transactions_raise_errors(tmp_path: Path) -> None:
+    tracker = FinanceTracker(tmp_path / "dados.json")
+    with pytest.raises(ValueError):
+        tracker.add_transaction("bonus", "Inválido", 100.0)
+    with pytest.raises(ValueError):
+        tracker.add_transaction("entrada", "Negativo", -10)


### PR DESCRIPTION
## Summary
- implement a persistent `FinanceTracker` to store financial transactions
- expose a CLI with commands to add, list and summarize entradas/saídas
- document installation/usage and cover core behaviour with pytest tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd61819c408330bff8f5ecee4d18f8